### PR TITLE
Improved object validation

### DIFF
--- a/src/validateDataType.js
+++ b/src/validateDataType.js
@@ -22,6 +22,12 @@ function validateDataType(candidate, dataType, models){
       return validate.primitive.void(candidate);
     case 'File':
       return validate.primitive.file();
+    case 'object':
+      if (dataType.properties) {
+        return validate.model(candidate, dataType.properties, models)
+      }
+      // intentionally fall through to default here so explicit `type: object`
+      // with $ref would be validated as well
     default:
       // Assumed to be object
       var model = models[type];

--- a/src/validateDataType.js
+++ b/src/validateDataType.js
@@ -1,10 +1,10 @@
 'use strict';
 
 var validate = require('./index');
-  
+
 function validateDataType(candidate, dataType, models){
   models = models || {};
-      
+
   var type = dataType.type || dataType.dataType || dataType.$ref;
 
   switch(type){
@@ -23,9 +23,11 @@ function validateDataType(candidate, dataType, models){
     case 'File':
       return validate.primitive.file();
     default:
-      // Assumed to be complex model
+      // Assumed to be object
       var model = models[type];
-      return validate.model(candidate, model, models);
+      if (model) {
+        return validate.model(candidate, model, models);
+      }
   }
 }
 module.exports = validateDataType;


### PR DESCRIPTION
Don't validate object when model is undefined:

``` yaml
properties:
  data:
    description: free form, unvalidated, when not given any $ref or type
```

Validate using the inner properties when type is `object`:

``` yaml
properties:
  data:
    type: object
    required:
    - foo
    properties:
      foo:
        type: string
```

Validate with a $ref when type is explicitly defined as `object`:

``` yaml
properties:
  data:
    type: object
    $ref: '#/definitions/Foo'
```
